### PR TITLE
Add continuous integration running browser unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "node"
+sudo: required
+addons:
+  chrome: stable
+script:
+  - npm start
+cache: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
+os: osx
 node_js:
-  - "node"
+  - node
 sudo: required
 addons:
   chrome: stable
+  firefox: latest
 script:
   - npm start
 cache: npm

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <a href="https://www.npmjs.com/package/yett"><img alt="npm-badge" src="https://img.shields.io/npm/v/yett.svg" height="20"></a>
   <a href="https://github.com/snipsco/yett/blob/master/LICENSE"><img alt="license-badge" src="https://img.shields.io/npm/l/yett.svg" height="20"></a>
   <a href="https://bundlephobia.com/result?p=yett"><img alt="size-badge" src="https://img.shields.io/bundlephobia/minzip/yett.svg"></a>
+  <a href="https://travis-ci.org/snipsco/yett"><img src="https://travis-ci.org/snipsco/yett.svg?branch=master" alt="ci-badge" height="20"></a>
   <a href="#browser-compatibility"><img src="https://badges.herokuapp.com/browsers?firefox=60&googlechrome=66&safari=11&iexplore=!9,!10,11&microsoftedge=17" alt="bundle-badge" height="20"></a>
 </h1>
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function(config) {
       logLevel: config.LOG_INFO,
       browsers: ['ChromeHeadless', 'FirefoxHeadless', 'Safari'],
       autoWatch: false,
-      concurrency: Infinity,
+      concurrency: 1,
       customLaunchers: {
         FirefoxHeadless: {
           base: 'Firefox',

--- a/test/test.js
+++ b/test/test.js
@@ -35,21 +35,23 @@ describe('Yett', () => {
             'script-blocked script has been downloaded'
         )
     })
-    it('should unblock scripts', async () => {
+    it('should unblock scripts', async function() {
+        this.timeout(10000)
+
         window.yett.unblock('script.js')
-        await new Promise(resolve => setTimeout(resolve, 500))
+        await new Promise(resolve => setTimeout(resolve, 1000))
         assertThatScriptDidExecute('script')
         assertThatScriptDidNotExecute('dynamic')
         assertThatScriptDidNotExecute('script-blocked')
 
         window.yett.unblock('dynamic.js')
-        await new Promise(resolve => setTimeout(resolve, 500))
+        await new Promise(resolve => setTimeout(resolve, 1000))
         assertThatScriptDidExecute('script')
         assertThatScriptDidExecute('dynamic')
         assertThatScriptDidNotExecute('script-blocked')
 
         window.yett.unblock()
-        await new Promise(resolve => setTimeout(resolve, 500))
+        await new Promise(resolve => setTimeout(resolve, 1000))
         assertThatScriptDidExecute('script')
         assertThatScriptDidExecute('dynamic')
         assertThatScriptDidExecute('script-blocked')


### PR DESCRIPTION
*Issue #2*

**Added [travis.ci integration](https://travis-ci.org/snipsco/yett) that uses karma to run unit tests for `Safari`,  `Chrome headless` and `Firefox headless`.**

The [tests](https://github.com/snipsco/yett/blob/master/test/test.js) cover:
- [YETT_BLACKLIST](https://github.com/snipsco/yett/blob/master/test/index-blacklist.html)
- [YETT_WHITELIST](https://github.com/snipsco/yett/blob/master/test/index-whitelist.html)
- `unblock()`
- `<script src='...' type='javascript/blocked' />` preventing script loading for `Chrome` & `Firefox`
