### PR TITLE
Change forEach to a for loop in MutationObserver callback

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -3,7 +3,8 @@ import { isOnBlacklist } from './checks'
 
 // Setup a mutation observer to track DOM insertion
 export const observer = new MutationObserver(mutations => {
-    mutations.forEach(({ addedNodes }) => {
+    for (let i = 0; i < mutations.length; i++) {
+        const { addedNodes } = mutations[i];
         for(let i = 0; i < addedNodes.length; i++) {
             const node = addedNodes[i]
             // For each added script tag
@@ -32,7 +33,7 @@ export const observer = new MutationObserver(mutations => {
                 }
             }
         }
-    })
+    }
 })
 
 // Starts the monitoring


### PR DESCRIPTION
Thanks for the awesome library!  I recently discovered this bug while using it.

ie11 does [not support](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach#Browser_Compatibility) using `forEach` on a list of `MutationRecords`.  This PR replaces the forEach function with a good 'ol for loop which can be used in older browsers.

Would you be up for integrating Yett with a tool like Browserstack?  If so, I'd be happy to take that on.

Thanks!